### PR TITLE
Add NAT64 Prefix

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -483,6 +483,7 @@ class DomainInfo {
   addrVersion() {
     if (this.addr) {
       if (/^64:ff9b::/.test(this.addr)) return "4";  // RFC6052
+      if (/^64:ff9b:1:/.test(this.addr)) return "4"; // RFC8215
       if (this.addr.indexOf(".") >= 0) return "4";
       if (this.addr.indexOf(":") >= 0) return "6";
     }


### PR DESCRIPTION
Adding the "Local-Use IPv4/IPv6 Translation Prefix" because people might run NAT64 statelessly in their networks, using 64:ff9b:1::/48
This should do the trick